### PR TITLE
Add DELETE Endpoint for Task Deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,5 +110,26 @@ def patch_task(task_id):
         logging.error(f"Error patching task {task_id}: {e}")
         return jsonify({"error": "An error occurred while updating the task"}), 500
 
+
+
+@app.route('/tasks/<int:task_id>', methods=['DELETE'])
+def delete_task(task_id):
+    """
+    Delete a task by its ID.
+    """
+    try:
+        # Find the task by its ID
+        for index, task in enumerate(tasks):
+            if task['id'] == task_id:
+                # Remove the task from the list
+                deleted_task = tasks.pop(index)
+                return jsonify({"message": "Task deleted", "task": deleted_task}), 200
+        return jsonify({"error": "Task not found"}), 404
+    except Exception as e:
+        logging.error(f"Error deleting task {task_id}: {e}")
+        return jsonify({"error": "An error occurred while deleting the task"}), 500
+
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5800, debug=True)


### PR DESCRIPTION
This PR adds a new DELETE endpoint to our Flask application to allow for the deletion of tasks by ID. The new endpoint:
	•	Accepts a task ID via the URL.
	•	Iterates over the in-memory tasks list to find and remove the matching task.
	•	Returns a JSON response confirming the deletion along with the details of the deleted task.
	•	Responds with appropriate error messages if the task is not found or if an error occurs during deletion.

This enhancement brings our task management API in line with CRUD standards, providing complete functionality for creating, reading, updating, and now deleting tasks.